### PR TITLE
Update shaders to use new keys

### DIFF
--- a/ApexLegends/shaders/tools.shader
+++ b/ApexLegends/shaders/tools.shader
@@ -4,192 +4,133 @@
 // NODRAWS
 textures/tools/toolsnodraw
 {
-    surfaceparm nodraw
-    surfaceparm nolightmap
-	surfaceparm nomarks
+    $compileflag nodraw
 }
 
 // CLIPS
 textures/tools/toolsclip
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_titan
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $contentflag titanclip
+    $compileflag nodraw
 }
 
 textures/tools/toolsplayerclip
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $contentflag playerclip
+    $contentflag noclimb
+    $compileflag nodraw
 }
 
 textures/tools/toolsnpcclip
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $contentflag monsterclip
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_human
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $contentflag playerclip
+    $contentflag noclimb
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_human_climbable
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $contentflag playerclip
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_concrete
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_metal
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_wood
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $compileflag nodraw
 }
 
 
 // TRIGGERS
 textures/tools/toolstrigger
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolstrigger_capturepoint
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolstrigger_checkpoint
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolstrigger_checkpoint_off
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolstrigger_flag
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolstrigger_spawn
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolsout_of_bounds
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 
 // SKIPS
 textures/tools/toolsskip
 {
-	qer_nocarve
-	qer_trans 0.30
-	surfaceparm nodraw
-	surfaceparm nonsolid
-	surfaceparm structural
-	surfaceparm trans
-	surfaceparm noimpact
-	surfaceparm skip
+    %trans 0.40
+    $contentflag nonsolid
+    $compileflag nodraw
 }
 
 // SKYBOX
 textures/tools/toolsskybox
 {
-    surfaceparm sky
+    $surfaceflag sky
+    $compileflag sky
 }
 
 textures/tools/toolsskybox2d
 {
-    surfaceparm sky2d
+    $surfaceflag sky2d
+    $compileflag sky
 }

--- a/Titanfall2/shaders/editormodels.shader
+++ b/Titanfall2/shaders/editormodels.shader
@@ -3,40 +3,40 @@
 
 models/dev/orange
 {
-    qer_editorimage textures/models/editor/orange.tga
+    %basetexture textures/models/editor/orange.tga
 }
 
 models/dev/gray
 {
-    qer_editorimage textures/models/editor/gray.tga
+    %basetexture textures/models/editor/gray.tga
 }
 
 models/editor/orange
 {
-    qer_editorimage textures/models/editor/orange.tga
+    %basetexture textures/models/editor/orange.tga
 }
 
 models/editor/gray
 {
-    qer_editorimage textures/models/editor/gray.tga
+    %basetexture textures/models/editor/gray.tga
 }
 
 models/signs/orange
 {
-    qer_editorimage textures/models/editor/orange.tga
+    %basetexture textures/models/editor/orange.tga
 }
 
 models/signs/gray
 {
-    qer_editorimage textures/models/editor/gray.tga
+    %basetexture textures/models/editor/gray.tga
 }
 
 models/robots/mobile_hardpoint/orange
 {
-    qer_editorimage textures/models/editor/orange.tga
+    %basetexture textures/models/editor/orange.tga
 }
 
 models/robots/mobile_hardpoint/gray
 {
-    qer_editorimage textures/models/editor/gray.tga
+    %basetexture textures/models/editor/gray.tga
 }

--- a/Titanfall2/shaders/editormodels.shader
+++ b/Titanfall2/shaders/editormodels.shader
@@ -3,40 +3,40 @@
 
 models/dev/orange
 {
-    %basetexture textures/models/editor/orange.tga
+    $basetexture textures/models/editor/orange.tga
 }
 
 models/dev/gray
 {
-    %basetexture textures/models/editor/gray.tga
+    $basetexture textures/models/editor/gray.tga
 }
 
 models/editor/orange
 {
-    %basetexture textures/models/editor/orange.tga
+    $basetexture textures/models/editor/orange.tga
 }
 
 models/editor/gray
 {
-    %basetexture textures/models/editor/gray.tga
+    $basetexture textures/models/editor/gray.tga
 }
 
 models/signs/orange
 {
-    %basetexture textures/models/editor/orange.tga
+    $basetexture textures/models/editor/orange.tga
 }
 
 models/signs/gray
 {
-    %basetexture textures/models/editor/gray.tga
+    $basetexture textures/models/editor/gray.tga
 }
 
 models/robots/mobile_hardpoint/orange
 {
-    %basetexture textures/models/editor/orange.tga
+    $basetexture textures/models/editor/orange.tga
 }
 
 models/robots/mobile_hardpoint/gray
 {
-    %basetexture textures/models/editor/gray.tga
+    $basetexture textures/models/editor/gray.tga
 }

--- a/Titanfall2/shaders/tools.shader
+++ b/Titanfall2/shaders/tools.shader
@@ -4,199 +4,141 @@
 // NODRAWS
 textures/tools/toolsnodraw
 {
-    surfaceparm nodraw
-    surfaceparm nolightmap
-	surfaceparm nomarks
+    $compileflag nodraw
 }
 
 // CLIPS
 textures/tools/toolsclip
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_titan
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $contentflag titanclip
+    $compileflag nodraw
 }
 
 textures/tools/toolsplayerclip
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $contentflag playerclip
+    $contentflag noclimb
+    $compileflag nodraw
 }
 
 textures/tools/toolsnpcclip
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $contentflag monsterclip
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_human
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $contentflag playerclip
+    $contentflag noclimb
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_human_climbable
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $contentflag playerclip
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_concrete
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_metal
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_wood
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $compileflag nodraw
 }
 
 
 // TRIGGERS
 textures/tools/toolstrigger
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolstrigger_capturepoint
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolstrigger_checkpoint
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolstrigger_checkpoint_off
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolstrigger_flag
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolstrigger_spawn
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolsout_of_bounds
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 
 // SKIPS
 textures/tools/toolsskip
 {
-	qer_nocarve
-	qer_trans 0.30
-	surfaceparm nodraw
-	surfaceparm nonsolid
-	surfaceparm structural
-	surfaceparm trans
-	surfaceparm noimpact
-	surfaceparm skip
+    %trans 0.40
+    $contentflag nonsolid
+    $compileflag nodraw
 }
 
 // SKYBOX
 textures/tools/toolsskybox
 {
-    surfaceparm sky
+    $surfaceflag sky
+    $compileflag sky
 }
 
 textures/tools/toolsskybox2d
 {
-    surfaceparm sky2d
+    $surfaceflag sky2d
+    $compileflag sky
 }
+
 
 textures/tools/toolslightprobevolume
 {
     qer_trans 0.30
-    surfaceparm nodraw
-    surfaceparm nonsolid
+    $contentflag nonsolid
+    $compileflag nodraw
 }

--- a/TitanfallOnline/shaders/editormodels.shader
+++ b/TitanfallOnline/shaders/editormodels.shader
@@ -3,40 +3,40 @@
 
 models/dev/orange
 {
-    qer_editorimage textures/models/editor/orange.tga
+    %basetexture textures/models/editor/orange.tga
 }
 
 models/dev/gray
 {
-    qer_editorimage textures/models/editor/gray.tga
+    %basetexture textures/models/editor/gray.tga
 }
 
 models/editor/orange
 {
-    qer_editorimage textures/models/editor/orange.tga
+    %basetexture textures/models/editor/orange.tga
 }
 
 models/editor/gray
 {
-    qer_editorimage textures/models/editor/gray.tga
+    %basetexture textures/models/editor/gray.tga
 }
 
 models/signs/orange
 {
-    qer_editorimage textures/models/editor/orange.tga
+    %basetexture textures/models/editor/orange.tga
 }
 
 models/signs/gray
 {
-    qer_editorimage textures/models/editor/gray.tga
+    %basetexture textures/models/editor/gray.tga
 }
 
 models/robots/mobile_hardpoint/orange
 {
-    qer_editorimage textures/models/editor/orange.tga
+    %basetexture textures/models/editor/orange.tga
 }
 
 models/robots/mobile_hardpoint/gray
 {
-    qer_editorimage textures/models/editor/gray.tga
+    %basetexture textures/models/editor/gray.tga
 }

--- a/TitanfallOnline/shaders/editormodels.shader
+++ b/TitanfallOnline/shaders/editormodels.shader
@@ -3,40 +3,40 @@
 
 models/dev/orange
 {
-    %basetexture textures/models/editor/orange.tga
+    $basetexture textures/models/editor/orange.tga
 }
 
 models/dev/gray
 {
-    %basetexture textures/models/editor/gray.tga
+    $basetexture textures/models/editor/gray.tga
 }
 
 models/editor/orange
 {
-    %basetexture textures/models/editor/orange.tga
+    $basetexture textures/models/editor/orange.tga
 }
 
 models/editor/gray
 {
-    %basetexture textures/models/editor/gray.tga
+    $basetexture textures/models/editor/gray.tga
 }
 
 models/signs/orange
 {
-    %basetexture textures/models/editor/orange.tga
+    $basetexture textures/models/editor/orange.tga
 }
 
 models/signs/gray
 {
-    %basetexture textures/models/editor/gray.tga
+    $basetexture textures/models/editor/gray.tga
 }
 
 models/robots/mobile_hardpoint/orange
 {
-    %basetexture textures/models/editor/orange.tga
+    $basetexture textures/models/editor/orange.tga
 }
 
 models/robots/mobile_hardpoint/gray
 {
-    %basetexture textures/models/editor/gray.tga
+    $basetexture textures/models/editor/gray.tga
 }

--- a/TitanfallOnline/shaders/tools.shader
+++ b/TitanfallOnline/shaders/tools.shader
@@ -4,192 +4,133 @@
 // NODRAWS
 textures/tools/toolsnodraw
 {
-    surfaceparm nodraw
-    surfaceparm nolightmap
-	surfaceparm nomarks
+    $compileflag nodraw
 }
 
 // CLIPS
 textures/tools/toolsclip
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_titan
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $contentflag titanclip
+    $compileflag nodraw
 }
 
 textures/tools/toolsplayerclip
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $contentflag playerclip
+    $contentflag noclimb
+    $compileflag nodraw
 }
 
 textures/tools/toolsnpcclip
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $contentflag monsterclip
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_human
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $contentflag playerclip
+    $contentflag noclimb
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_human_climbable
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $contentflag playerclip
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_concrete
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_metal
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolsclip_wood
 {
-    qer_trans 0.40
-	surfaceparm nodraw
-	surfaceparm nolightmap
-	surfaceparm nonsolid
-	surfaceparm trans
-	surfaceparm nomarks
-	surfaceparm noimpact
-	surfaceparm playerclip
+    %trans 0.40
+    $compileflag nodraw
 }
 
 
 // TRIGGERS
 textures/tools/toolstrigger
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolstrigger_capturepoint
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolstrigger_checkpoint
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolstrigger_checkpoint_off
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolstrigger_flag
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolstrigger_spawn
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 textures/tools/toolsout_of_bounds
 {
-    qer_trans 0.50
-	qer_nocarve
-	surfaceparm nodraw
+    %trans 0.40
+    $compileflag nodraw
 }
 
 
 // SKIPS
 textures/tools/toolsskip
 {
-	qer_nocarve
-	qer_trans 0.30
-	surfaceparm nodraw
-	surfaceparm nonsolid
-	surfaceparm structural
-	surfaceparm trans
-	surfaceparm noimpact
-	surfaceparm skip
+    %trans 0.40
+    $contentflag nonsolid
+    $compileflag nodraw
 }
 
 // SKYBOX
 textures/tools/toolsskybox
 {
-    surfaceparm sky
+    $surfaceflag sky
+    $compileflag sky
 }
 
 textures/tools/toolsskybox2d
 {
-    surfaceparm sky2d
+    $surfaceflag sky2d
+    $compileflag sky
 }


### PR DESCRIPTION
Updates all `.shader` files to use the new shader keys.

Depends on [#42](https://github.com/MRVN-Radiant/MRVN-Radiant/pull/42)